### PR TITLE
Join the Android Go forces

### DIFF
--- a/aosp_go_e2303.mk
+++ b/aosp_go_e2303.mk
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PRODUCT_MAKEFILES := $(LOCAL_DIR)/aosp_e2303.mk \
-                     $(LOCAL_DIR)/aosp_e2333.mk \
-                     $(LOCAL_DIR)/aosp_go_e2303.mk \
-                     $(LOCAL_DIR)/aosp_go_e2333.mk
+TARGET_KERNEL_CONFIG := aosp_kanuti_tulip_defconfig
+
+# Inherit from those products. Most specific first.
+$(call inherit-product, device/sony/tulip/device.mk)
+$(call inherit-product, frameworks/native/build/phone-xhdpi-2048-dalvik-heap.mk)
+$(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base_telephony.mk)
+# Inherit common Android Go configurations
+$(call inherit-product, build/target/product/go_defaults.mk)
+
+PRODUCT_NAME := aosp_e2303
+PRODUCT_DEVICE := tulip
+PRODUCT_MODEL := Xperia M4 Aqua (AOSP Go)
+PRODUCT_BRAND := Sony
+PRODUCT_MANUFACTURER := Sony

--- a/aosp_go_e2333.mk
+++ b/aosp_go_e2333.mk
@@ -12,7 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PRODUCT_MAKEFILES := $(LOCAL_DIR)/aosp_e2303.mk \
-                     $(LOCAL_DIR)/aosp_e2333.mk \
-                     $(LOCAL_DIR)/aosp_go_e2303.mk \
-                     $(LOCAL_DIR)/aosp_go_e2333.mk
+# Inherit from those products. Most specific first.
+$(call inherit-product, device/sony/tulip/aosp_go_e2303.mk)
+
+# Reserve space for data encryption (12213813248-16384)
+BOARD_USERDATAIMAGE_PARTITION_SIZE := 12213796864
+
+# DualSim
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.multisim.config=dsds \
+    persist.radio.multisim.config=dsds \
+    ro.telephony.default_network=9,1
+
+PRODUCT_NAME := aosp_e2333
+PRODUCT_DEVICE := tulip
+PRODUCT_MODEL := Xperia M4 Aqua Dual (AOSP Go)
+PRODUCT_BRAND := Sony
+PRODUCT_MANUFACTURER := Sony

--- a/vendorsetup.sh
+++ b/vendorsetup.sh
@@ -16,3 +16,5 @@
 
 add_lunch_combo aosp_e2303-userdebug
 add_lunch_combo aosp_e2333-userdebug
+add_lunch_combo aosp_go_e2303-userdebug
+add_lunch_combo aosp_go_e2333-userdebug


### PR DESCRIPTION
8gigs of rom + 2 gigs of ram = possibly a good device to use Android Go configs on
Signed-off-by: Konrad Dybcio <ewentualxpl@gmail.com>